### PR TITLE
Add dependabot config to update Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    open-pull-requests-limit: 30
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Most of the CI checks are failing due to old GH Action steps, this should help keep them updated (after merging this PR, dependabot will open a PR on `upload-artifact` action and this should fix the build). The config is a subset of what we are using in https://github.com/eclipse-lyo/lyo/blob/master/.github/dependabot.yml and should be good as a first step.